### PR TITLE
将 2019 年后的 "NOI D类" 更正为 "NOI 夏令营"

### DIFF
--- a/static/contests.json
+++ b/static/contests.json
@@ -593,7 +593,7 @@
 	{
 		"fall_semester": false,
 		"full_score": 705,
-		"name": "NOI2020D类",
+		"name": "NOI2020夏令营",
 		"type": "NOID类",
 		"year": 2020
 	},

--- a/static/contests.json
+++ b/static/contests.json
@@ -543,7 +543,7 @@
 	{
 		"fall_semester": false,
 		"full_score": 705,
-		"name": "NOI2019D类",
+		"name": "NOI2019夏令营",
 		"type": "NOID类",
 		"year": 2019
 	},
@@ -658,7 +658,7 @@
 	{
 		"fall_semester": false,
 		"full_score": 705,
-		"name": "NOI2021D类",
+		"name": "NOI2021夏令营",
 		"type": "NOID类",
 		"year": 2021
 	},
@@ -729,7 +729,7 @@
 	{
 		"fall_semester": false,
 		"full_score": 705,
-		"name": "NOI2022D类",
+		"name": "NOI2022夏令营",
 		"type": "NOID类",
 		"year": 2022
 	},
@@ -799,7 +799,7 @@
 	{
 		"fall_semester": false,
 		"full_score": 705,
-		"name": "NOI2023D类",
+		"name": "NOI2023夏令营",
 		"type": "NOID类",
 		"year": 2023
 	},
@@ -863,7 +863,7 @@
 	{
 		"fall_semester": false,
 		"full_score": 705,
-		"name": "NOI2024D类",
+		"name": "NOI2024夏令营",
 		"type": "NOID类",
 		"year": 2024
 	},


### PR DESCRIPTION
Resolves OIerDb-ng/OIerDb#101.

> 考虑到 2019 年之后夏令营增加了 E 类选手（初中生），再以 D 类选手代指夏令营选手感觉确实有以偏概全之嫌，将 D 类改为夏令营能有效反映这一变化，用词也更加准确。

---

本 Pull Request 更正了 2019 年后的 "NOI 夏令营" 在 OIerDb 中的显示名称。

至于 2019 年以前，在 CCF NOI 官网上显示为 D 类、邀请赛等名称，故为了保持显示统一便于查询，未做修改。

cc @StudyingFather.