### PR TITLE
fix: 明确限定文件读写时使用 utf-8 编码

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def __main__():
     def parse_school():
         "解析 school.txt 文件。"
 
-        with open("data/school.txt") as f:
+        with open("data/school.txt", encoding="utf-8") as f:
             raw_data = f.readlines()
         for idx, line in tqdm(enumerate(raw_data), total=len(raw_data)):
             try:
@@ -91,7 +91,7 @@ def __main__():
     def parse_raw():
         "解析 raw.txt 文件。"
 
-        with open("data/raw.txt") as f:
+        with open("data/raw.txt", encoding="utf-8") as f:
             raw_data = f.readlines()
         for idx, line in tqdm(enumerate(raw_data), total=len(raw_data)):
             try:
@@ -230,7 +230,7 @@ def __main__():
 
         nonlocal new_schools
         new_schools = sorted(set(new_schools))
-        with open("dist/merge_preview.txt", "w") as f:
+        with open("dist/merge_preview.txt", "w", encoding="utf-8") as f:
             print(
 """# 用 '#' 号表示注释。
 # 这是由 main.py 自动生成的学校合并确认文件，本文件的格式有如下几种：
@@ -280,14 +280,14 @@ def __main__():
         output = []
         for school in tqdm(School.get_all()):
             output.append([school.name, school.province, school.city, float(round(school.score, 2))])
-        with open("dist/school.json", "w", newline="\n") as f:
+        with open("dist/school.json", "w", newline="\n", encoding="utf-8") as f:
             json.dump(output, f, ensure_ascii=False)
 
     def output_compressed():
         "输出压缩的结果，不压缩的结果先咕着。"
 
         OIer.sort_by_score()
-        with open("dist/result.txt", "w", newline="\n") as f:
+        with open("dist/result.txt", "w", newline="\n", encoding="utf-8") as f:
             for oier in tqdm(OIer.get_all()):
                 print(oier.to_compress_format(), file=f, end="\n")
 
@@ -301,7 +301,7 @@ def __main__():
 
         with open("dist/result.txt", "rb") as f:
             sha512 = hashlib.sha512(f.read()).hexdigest()
-        with open("dist/result.info.json", "w", newline="\n") as f:
+        with open("dist/result.info.json", "w", newline="\n", encoding="utf-8") as f:
             print('{"sha512":"' + sha512 + '", "size":' + str(file_size) + "}", file=f)
 
     def update_static():

--- a/util.py
+++ b/util.py
@@ -68,23 +68,23 @@ def __main__():
 
     global add_contestant, contests, contest_type_coefficient, decay_coefficient, enrollment_middle, get_contest_id, get_grades, get_initials, get_mode, get_weighted_mode, lcs, rank_coefficient
 
-    with open("static/contests.json") as f:
+    with open("static/contests.json", encoding="utf-8") as f:
         for contest in json.load(f):
             Contest.create(contest)
 
-    with open("static/grades.json") as f:
+    with open("static/grades.json", encoding="utf-8") as f:
         g_ = json.load(f)
     g_initial = g_["initial"]
     g_element = g_["element"]
     g_special = g_["special"]
 
-    with open("static/surnames.json") as f:
+    with open("static/surnames.json", encoding="utf-8") as f:
         surnames = json.load(f)
 
-    with open("static/scoring.json") as f:
+    with open("static/scoring.json", encoding="utf-8") as f:
         scoring = json.load(f)
 
-    with open("static/name_exceptions.json") as f:
+    with open("static/name_exceptions.json", encoding="utf-8") as f:
         name_exceptions = json.load(f)
 
     pypinyin.load_single_dict({ ord(k): v for k, v in name_exceptions.items() })


### PR DESCRIPTION
在所有 `open` 语句中添加参数 `encoding='utf-8'`，防止使用操作系统默认编码（如 Windows 下 GBK）而报错。